### PR TITLE
🐞 Fix TypeScript modules error

### DIFF
--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -1,4 +1,4 @@
-<script lang="ts"></script>
+<script lang="ts" setup></script>
 
 <template>
   <div></div>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,4 +1,4 @@
-<script lang="ts"></script>
+<script lang="ts" setup></script>
 
 <template>
   <div


### PR DESCRIPTION
# Description
TypeScript was throwing an error on the Calendar component that the Day and Sidebar components where not modules

## Type of change
- [x] Bug fix

# Checklist:
- [x] Adding the 'setup' keyword to the 'script' tags of those respective components solved the issue
