### PR TITLE
🐞🌈 Fix day header moving on scroll

### DIFF
--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -1,18 +1,14 @@
 <template>
   <div
     ref="day"
-    class="bg-amber-500 m-[1px] grid grid-rows-[repeat(24,_minmax(3em,_1fr))] grid-cols-1 border-t-black back-grid"
+    class="bg-amber-500 m-[1px] grid grid-rows-[repeat(24,_minmax(3em,_1fr))] grid-cols-1 border-t-black bg-[length:100%_48.8281px] back_gradient-grid h-full"
   ></div>
 </template>
 
 <script lang="ts" setup></script>
 
 <style scoped>
-.back-grid {
-  background-position-y: 8em;
-  background-size: 100% calc(1em + 30px);
-  background-position: top;
-  background-repeat: repeat-y;
+.back_gradient-grid {
   background-image: linear-gradient(
     to bottom,
     black 0%,

--- a/src/components/DayHeader.vue
+++ b/src/components/DayHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-pink-300 top-0 left-0 sticky h-[10%]">{{ date }}</div>
+  <div class="bg-pink-300 top-0 left-0 sticky h-[5%]">{{ date }}</div>
 </template>
 
 <script lang="ts" setup>

--- a/src/components/Days.vue
+++ b/src/components/Days.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-for="(days, index) in weekView" class="min-h-fit">
+  <div v-for="(days, index) in weekView">
     <DayHeader :date="readableWeekDate[index]" class="z-10" />
     <Day class="z-0" />
   </div>


### PR DESCRIPTION
# Description
The day header would move and hide on the last stretch of scrolling when viewing late night hours so a fix was needed to maintain the date header always visible as a sticky element

## Type of change
- [x] Bug fix
- [x] Styling

# Checklist:
- [x] Give full-height to both `Day.vue`
- [x] Remove the `height` styling from `DayHeader.vue`
- [x] Removing unnecessary CSS to achieve a visual background grid
- [x] Converting to `Tailwind` the necessary classes (except the linear gradient)
- [x] Renaming the `back_grid` to `back_gradient-grid`