### PR TITLE
✨🧬 Adding calendar hours display

### DIFF
--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -2,7 +2,9 @@
   <div
     ref="day"
     class="bg-amber-500 m-[1px] grid grid-rows-[repeat(24,_minmax(3em,_1fr))] grid-cols-1 border-t-black bg-[length:100%_48.8281px] back_gradient-grid h-full"
-  ></div>
+  >
+    <slot name="hours"></slot>
+  </div>
 </template>
 
 <script lang="ts" setup></script>

--- a/src/components/Days.vue
+++ b/src/components/Days.vue
@@ -1,13 +1,26 @@
 <template>
-  <div v-for="(days, index) in weekView">
-    <DayHeader :date="readableWeekDate[index]" class="z-10" />
-    <Day class="z-0" />
+  <div
+    class="row-start-3 row-end-[12] bg-blue-500 col-start-3 col-end-[12] grid-cols-8 grid overflow-y-scroll overflow-x-hidden relative"
+  >
+    <div class="h-full">
+      <DayHeader class="z-10" />
+      <Day class="z-0">
+        <template #hours>
+          <Hours v-for="(hour, index) in hours" :hour="index + 1" />
+        </template>
+      </Day>
+    </div>
+    <div v-for="(days, index) in weekView">
+      <DayHeader :date="readableWeekDate[index]" class="z-10" />
+      <Day class="z-0" />
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
 import Day from './Day.vue';
 import DayHeader from '../components/DayHeader.vue';
+import Hours from './Hours.vue';
 import {
   getCurrentWeekDates,
   convertToReadableWeekDates,
@@ -16,5 +29,6 @@ import {
 const currentWeek = getCurrentWeekDates();
 const readableWeekDate = convertToReadableWeekDates(currentWeek);
 
+const hours = 23;
 const weekView = getCurrentWeekDates();
 </script>

--- a/src/components/Hours.vue
+++ b/src/components/Hours.vue
@@ -1,0 +1,12 @@
+<!-- TODO: Temporary -->
+<template>
+  <div class="h-[48.8281px] border-t relative overflow-visible">
+    <span class="absolute right-0 bottom-[-10.5px]">{{ hour + ':00' }}</span>
+  </div>
+</template>
+
+<script lang="ts" setup>
+const props = defineProps({
+  hour: Number,
+});
+</script>

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -2,11 +2,7 @@
   <div
     class="w-full h-full grid grid-cols-12 grid-rows-[repeat(12,minmax(0,1fr))] bg-[#f8673b] overflow-hidden"
   >
-    <div
-      class="row-start-3 row-end-[12] bg-blue-500 col-start-4 col-end-[12] grid-cols-7 grid overflow-y-scroll overflow-x-hidden relative"
-    >
-      <Days />
-    </div>
+    <Days />
     <Sidebar />
   </div>
 </template>


### PR DESCRIPTION
# Description
Calendar needs to have a visual hour indication next to the the calendar chosen view

## Type of change
- [x] New feature
- [x] Refactoring

## Checklist:
- [x] Moved the `div` containing the grid days formatting to the `Days.vue` component to avoid a `fragment`
- [x] Created the `Hours.vue` component to control the calendar's hours display
- [x] Re-used the `Days.vue` and `DayHeader.vue` components to generate the `Hours.vue` container and maintain the grid formatting
- [x] Added a named `slots` 'hours' to generate the `Hours.vue` items (temporary implementation)