### PR TITLE
🧬 Moving 'DayHeader.vue' component into 'Day.vue' component

### DIFF
--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -1,16 +1,30 @@
 <template>
-  <div
-    class="m-[1px] grid grid-rows-[repeat(24,_minmax(3em,_1fr))] grid-cols-1 bg-[length:100%_48.8281px] h-full"
-    :class="{ 'back_gradient-grid': !isBlank }"
-  >
-    <slot name="hours"></slot>
+  <div class="h-full">
+    <DayHeader
+      :date="readableWeekDates[index!]"
+      class="z-10"
+      :isBlank="isBlank"
+    />
+    <div
+      class="m-[1px] grid grid-rows-[repeat(24,_minmax(3em,_1fr))] grid-cols-1 bg-[length:100%_48.8281px] h-full"
+      :class="{ 'back_gradient-grid': !isBlank }"
+    >
+      <slot name="hours"></slot>
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
+import DayHeader from './DayHeader.vue';
+import { convertToReadableWeekDates, getCurrentWeekDates } from './utils';
+
 const props = defineProps({
+  index: Number,
   isBlank: Boolean,
 });
+
+const weekDates = getCurrentWeekDates();
+const readableWeekDates = convertToReadableWeekDates(weekDates, true);
 </script>
 
 <style scoped>

--- a/src/components/Days.vue
+++ b/src/components/Days.vue
@@ -3,17 +3,13 @@
     class="row-start-3 row-end-[12] col-start-3 col-end-[12] grid-cols-8 grid overflow-y-scroll overflow-x-hidden relative"
   >
     <div class="h-full">
-      <DayHeader isBlank class="z-10" />
       <Day isBlank class="z-0">
         <template #hours>
           <Hours v-for="(hour, index) in hours" :hour="index + 1" />
         </template>
       </Day>
     </div>
-    <div v-for="(days, index) in weekDates">
-      <DayHeader :date="readableWeekDates[index]" class="z-10" />
-      <Day class="z-0" />
-    </div>
+    <Day class="z-0" v-for="(days, index) in weekDates" :index="index" />
   </div>
 </template>
 
@@ -21,12 +17,8 @@
 import Day from './Day.vue';
 import DayHeader from '../components/DayHeader.vue';
 import Hours from './Hours.vue';
-import {
-  getCurrentWeekDates,
-  convertToReadableWeekDates,
-} from './../components/utils';
+import { getCurrentWeekDates } from './../components/utils';
 
 const weekDates = getCurrentWeekDates();
-const readableWeekDates = convertToReadableWeekDates(weekDates, true);
 const hours = 23;
 </script>


### PR DESCRIPTION
# Description
Avoid the creation of 'fragments' when using the 'v-for' loop making each component passible to maintain it's formatting by itself

## Type of change
- [x] Refactor

# Checklist:
- [x] Move 'DayHeader.vue' component into 'Day.vue' component
- [x] Move some of the 'utils' function logic into 'DayHeader.vue'
- [x] Moved 'div's responsible for the correct day formatting
- [x] Added 'index' prop on 'Day.vue' component
- [x] Slight styling re-touch
