### PR TITLE
🌈 Styling Overhaul 2 (Scrollbar & Hover)

### DIFF
--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -6,7 +6,7 @@
       :isBlank="isBlank"
     />
     <div
-      class="m-[1px] grid grid-rows-[repeat(24,_minmax(3em,_1fr))] grid-cols-1 bg-[length:100%_48.8281px] h-full"
+      class="m-[1px] grid grid-rows-[repeat(24,_minmax(3em,_1fr))] grid-cols-1 bg-[length:100%_48.8281px] h-full hover:border-2"
       :class="{ 'back_gradient-grid': !isBlank }"
     >
       <slot name="hours"></slot>
@@ -28,10 +28,10 @@ const readableWeekDates = convertToReadableWeekDates(weekDates, true);
 </script>
 
 <style scoped>
-.back_gradient-grid {
+.back_gradient-grid:hover {
   background-image: linear-gradient(
     to bottom,
-    black 0%,
+    rgb(229, 231, 235) 0%,
     transparent 1px,
     transparent 100%
   );

--- a/src/components/DayHeader.vue
+++ b/src/components/DayHeader.vue
@@ -3,7 +3,7 @@
     <span class="text-black">{{ date }}</span>
     <span
       v-if="!isBlank"
-      class="w-11/12 h-[3px] rounded-full bg-black bottom-0 left-0 absolute"
+      class="w-11/12 h-[3px] rounded-full bg-gray-200 bottom-0 left-0 absolute"
     ></span>
   </div>
 </template>

--- a/src/components/Days.vue
+++ b/src/components/Days.vue
@@ -30,3 +30,18 @@ import { getCurrentWeekDates } from './../components/utils';
 const weekDates = getCurrentWeekDates();
 const hours = 23;
 </script>
+<style scoped>
+*::-webkit-scrollbar {
+  width: 6px;
+  background-color: transparent;
+}
+
+/* *::-webkit-scrollbar-track {
+  background: orange;
+} */
+
+*::-webkit-scrollbar-thumb {
+  background-color: rgb(229, 231, 235);
+  border-radius: 50px;
+}
+</style>

--- a/src/components/Hours.vue
+++ b/src/components/Hours.vue
@@ -1,7 +1,7 @@
 <!-- TODO: Temporary -->
 <template>
   <div class="h-[48.8281px] relative overflow-visible">
-    <span class="absolute right-0 bottom-[-10.5px] text-black">{{
+    <span class="absolute right-1/4 bottom-[-10.5px] text-black">{{
       hour + ':00'
     }}</span>
   </div>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,7 +1,5 @@
 <script lang="ts" setup></script>
 
 <template>
-  <div
-    class="col-start-1 col-end-3 row-start-1 row-end-[-1] bg-[#f95729]"
-  ></div>
+  <div class="col-start-1 col-end-3 row-start-1 row-end-[-1] border-r-2"></div>
 </template>


### PR DESCRIPTION
Why
- Overhaul to achieve the proposed wireframe

How
- Re-styled and recolored scrollbar
- Made the calendar grid only appear on the respective hovered day, to avoid visual cluttering (will be optional on the future)
- Reworked the grid (it needs more work)
- Fiddled with the calendar colours

# Description
Overall restyling, with some scrollbar and calendar grid showing only when on `hover`

## Type of change
- [x] Styling

# Checklist:
- [x] Re-styled and recolored scrollbar
- [x] Made the calendar grid only appear on the respective hovered day, to avoid visual cluttering (will be optional on the future)
- [x] Reworked the grid (it needs more work)
- [x] Fiddled with the calendar colours