### PR TITLE
🌈✨ Styling Overhaul 3 (Fixing background grid limits) and adding 'EventHeader' component

### DIFF
--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -6,8 +6,10 @@
       :isBlank="isBlank"
     />
     <div
-      class="m-[1px] grid grid-rows-[repeat(24,_minmax(3em,_1fr))] grid-cols-1 bg-[length:100%_48.8281px] h-full hover:border-2"
-      :class="{ 'back_gradient-grid': !isBlank }"
+      class="group grid grid-rows-[repeat(24,_minmax(3em,_1fr))] grid-cols-1 bg-[length:100%_48.8281px] h-full border-x border-transparent"
+      :class="{
+        'back_gradient-grid  hover:border-x-gray-200': !isBlank,
+      }"
     >
       <slot name="hours"></slot>
     </div>

--- a/src/components/DayHeader.vue
+++ b/src/components/DayHeader.vue
@@ -1,14 +1,17 @@
 <template>
-  <div class="top-0 left-0 sticky h-[5%] mx-[2px] bg-white">
+  <div class="top-0 left-0 sticky h-[5%] px-1 bg-white">
     <span class="text-black">{{ date }}</span>
     <span
       v-if="!isBlank"
       class="w-11/12 h-[3px] rounded-full bg-gray-200 bottom-0 left-0 absolute"
     ></span>
+    <EventHeader v-if="!isBlank" />
   </div>
 </template>
 
 <script lang="ts" setup>
+import EventHeader from './EventHeader.vue';
+
 const props = defineProps({
   isBlank: Boolean,
   date: String,

--- a/src/components/EventHeader.vue
+++ b/src/components/EventHeader.vue
@@ -1,0 +1,6 @@
+<template>
+  <div
+    class="w-full min-h-[4px] absolute left-0 bottom-0 translate-y-full bg-white"
+  ></div>
+</template>
+<script setup lang="ts"></script>


### PR DESCRIPTION
# Description
Adding the 'EventHeader' component to help hiding the top background limit which will be useful later to deal with full-day events

## Type of change
- [x] New feature
- [x] Styling

# Checklist:

- Fixed the `day_header` background not covering the `Day` component completely when scrolling replacing `mx-[2px]` with `px-1`
- Fixed the border appearing on the `Hours` component using the `isBlank` prop to conditionally insert the classes
- Fixed the top of the `background_grid` limit showing
- Added an `EventHeader` component which helped hiding the top background limit and will be useful for `events` later
