### PR TITLE
⭐ Adding `EventModal` with keyboard navigation

### DIFF
--- a/src/components/atoms/EventModal/EventModal.vue
+++ b/src/components/atoms/EventModal/EventModal.vue
@@ -1,0 +1,127 @@
+<template>
+  <Teleport to="body">
+    <dialog
+      id="modal"
+      :open="show"
+      ref="trapRef"
+      class="fixed left-0 top-0 z-10 flex h-screen w-screen items-center justify-center bg-black bg-opacity-50 backdrop-blur-sm"
+      @keydown.esc.exact="closeModal"
+      @click.self="closeModal"
+    >
+      <div class="flex w-1/3 flex-col gap-8 rounded-lg bg-slate-100 p-4">
+        <form class="flex flex-col gap-2">
+          <input
+            type="text"
+            placeholder="Add a title"
+            ref="modalInput"
+            class="bg-slate-100 p-1 text-lg"
+            v-model.trim="eventTitle"
+          />
+          <input
+            type="date"
+            placeholder="Insert a date"
+            class="bg-slate-100 p-1"
+            v-model="eventDate"
+          />
+          <input
+            type="number"
+            min="0"
+            max="23"
+            placeholder="Insert an hour (0 - 23)"
+            class="bg-slate-100 p-1"
+            v-model="eventHour"
+          />
+        </form>
+        <hr />
+        <div class="flex justify-end gap-8 align-bottom">
+          <Button
+            class="rounded-lg bg-slate-100 px-6 py-2 font-bold text-black active:translate-y-[1px]"
+            @click="closeModal"
+            >Close</Button
+          >
+          <Button
+            class="rounded-lg bg-[#f5a278] px-6 py-2 font-bold text-white active:translate-y-[1px]"
+            @click="addEvent"
+            >Create</Button
+          >
+        </div>
+      </div>
+    </dialog>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { useCalendarStore } from '@/stores/calendarStore';
+import type { CalendarEvent } from '@/types';
+import useFocusTrap from '@/composables/useFocusTrap';
+import Button from '@/components/molecules/Button';
+
+const { show } = defineProps<{
+  show: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close', show: boolean): void;
+}>();
+
+const store = useCalendarStore();
+const modalInput = ref<HTMLInputElement | null>(null);
+const eventTitle = ref('');
+const eventDate = ref('');
+const eventHour = ref('');
+const { trapRef, clearFocusTrap } = useFocusTrap();
+
+function closeModal() {
+  clearFocusTrap();
+  emit('close', false);
+}
+
+function addEvent() {
+  // TODO: handle the add event logic
+  const existingEvent = store.events.find(
+    (event) => event.date === eventDate.value
+  );
+
+  if (existingEvent) {
+    existingEvent.events?.push({
+      eventName: eventTitle?.value,
+      eventHour: eventHour.value,
+    });
+  } else {
+    const eventObject: CalendarEvent = {
+      date: eventDate.value,
+      events: [
+        {
+          eventName: eventTitle.value,
+          eventHour: eventHour.value,
+        },
+      ],
+    };
+
+    store.events.push(eventObject);
+  }
+}
+
+onMounted(() => {
+  modalInput.value?.focus();
+});
+</script>
+
+<style>
+#modal button {
+  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.15);
+}
+
+#modal button:hover {
+  background-color: rgba(245, 162, 120, 0.4);
+}
+
+#modal button:active {
+  box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.15);
+}
+
+#modal > div {
+  box-shadow: 0 0 4px 2px rgba(0, 0, 0, 0.25);
+}
+</style>

--- a/src/components/atoms/EventModal/index.ts
+++ b/src/components/atoms/EventModal/index.ts
@@ -1,0 +1,2 @@
+import EventModal from './EventModal.vue';
+export default EventModal;

--- a/src/components/organisms/Header/Header.vue
+++ b/src/components/organisms/Header/Header.vue
@@ -15,18 +15,22 @@
     </div>
     <Button
       class="rounded-lg bg-slate-100 px-6 py-2 font-bold text-black active:translate-y-[1px]"
+      @click="handleModal"
       >Add Event</Button
     >
+    <EventModal v-if="showModal" :show="showModal" @close="handleModal" />
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, computed } from 'vue';
 import Button from '@/components/molecules/Button';
-import { computed } from 'vue';
+import EventModal from '@/components/atoms/EventModal';
 import { useCalendarStore } from '@/stores/calendarStore';
 import { getCurrentDates, setCurrentDates } from '@/utils/Dates';
 
 const store = useCalendarStore();
+const showModal = ref(false);
 store.view = getCurrentDates();
 
 // TODO: Rework this as an external snippet
@@ -43,5 +47,9 @@ function moveForward() {
 
 function moveBackwards() {
   store.view = setCurrentDates(store.view, false);
+}
+
+function handleModal() {
+  showModal.value = !showModal.value;
 }
 </script>

--- a/src/composables/useFocusTrap.ts
+++ b/src/composables/useFocusTrap.ts
@@ -1,0 +1,64 @@
+import { customRef } from 'vue';
+
+const focusableElementsSelector =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+const useFocusTrap = () => {
+  let focusableElements = [];
+  let $firstFocusable: HTMLElement;
+  let $lastFocusable: HTMLElement;
+  const trapRef = customRef((track, trigger) => {
+    let $trapEl: any = null;
+    return {
+      get() {
+        track();
+        return $trapEl;
+      },
+      set(value) {
+        $trapEl = value;
+        value ? initFocusTrap() : clearFocusTrap();
+        trigger();
+      },
+    };
+  });
+
+  function keyHandler(e: KeyboardEvent) {
+    const isTabPressed = e.key === 'Tab';
+    if (!isTabPressed) return;
+    if (e.shiftKey) {
+      if (document.activeElement === $firstFocusable) {
+        $lastFocusable.focus();
+        e.preventDefault();
+      }
+    } else {
+      if (document.activeElement === $lastFocusable) {
+        $firstFocusable.focus();
+        e.preventDefault();
+      }
+    }
+  }
+
+  function initFocusTrap() {
+    // Bail out if there is no value
+    if (!trapRef.value) return;
+    focusableElements = trapRef.value.querySelectorAll(
+      focusableElementsSelector
+    );
+    $firstFocusable = focusableElements[0];
+    $lastFocusable = focusableElements[focusableElements.length - 1];
+    document.addEventListener('keydown', keyHandler);
+    // $firstFocusable.focus();
+  }
+
+  function clearFocusTrap() {
+    document.removeEventListener('keydown', keyHandler);
+  }
+
+  return {
+    trapRef,
+    initFocusTrap,
+    clearFocusTrap,
+  };
+};
+
+export default useFocusTrap;

--- a/src/views/pages/DefaultLayout/DefaultLayout.vue
+++ b/src/views/pages/DefaultLayout/DefaultLayout.vue
@@ -11,11 +11,10 @@
     >
       <Header />
       <Calendar />
-      <Button
-        :icon="sidebarOpen ? 'SidebarCollapse' : 'SidebarOpen'"
-        class="absolute left-1 top-1 h-6 w-6"
-        @click="sidebarToggle()"
-      />
+      <Button class="absolute left-1 top-1 h-6 w-6" @click="sidebarToggle()">
+        <IconLoader v-if="sidebarOpen" name="SidebarCollapse" />
+        <IconLoader v-else name="SidebarExpand" />
+      </Button>
     </section>
   </div>
 </template>
@@ -25,6 +24,7 @@ import Sidebar from '@/components/organisms/Sidebar';
 import Header from '@/components/organisms/Header';
 import Calendar from '@/components/organisms/Calendar';
 import Button from '@/components/molecules/Button';
+import IconLoader from '@/components/atoms/IconLoader';
 import { onMounted, onUnmounted, ref } from 'vue';
 
 const sidebarOpen = ref(true);


### PR DESCRIPTION
# Description
[comment]: # (Please include a summary of the change and which issue is fixed, if such. Please also include relevant motivation and context. List any dependencies that are required for this change)
[comment]: # (If the PR closes any opened issue, please use 'Fixes #issueID')

Added a first draft of the `EventModal` with some keyboard navigation accessibility: *Modal Focus*, *Focus Trap*, *Escape to close*, *Close on outside click*

## Type of change
[comment]: # (They can be: ✨ Feature | 🐞 Bug | 📙 Documentation | 🧶 Chore | 🧬 Refactor | ⚡ Test | 🌈 Styling | 🔥 Enhancement | 💣 Breaking Change | 📦 Package)

- [x] ⭐ Feature

## Changes:
[comment]: # (Place here the more granular changes you've made)

- Used `v-if` to change the calendar `button` responsible for the expansion/collapse of the `Sidebar`
- Built a `EventModal` atom to (futurely) handle event details inputs from the user
- Implemented automatic `focus` on the first the `EventModal`
- Implemented closing the `EventModal` using the `ESC` keyboard key
- Implemented the modal closing when clicking the `backdrop`
- Added a custom **focus trap** `composable` to the `EventModal`
- First draft of connecting the `EventModal` with the `Calendar` days and hours