### PR TITLE
🐞🧶🧬🌈⚡ Bug fixes, adding reactive `props` destructure and `EventCard` restyle

### DIFF
--- a/src/components/atoms/EventCard/EventCard.spec.ts
+++ b/src/components/atoms/EventCard/EventCard.spec.ts
@@ -1,0 +1,118 @@
+import { mount } from '@vue/test-utils';
+import EventCard from './EventCard.vue';
+import EventModal from '@/components/atoms/EventModal';
+
+describe('EventCard', () => {
+  it('should render a card displaying the correct title', () => {
+    const wrapper = mount(EventCard, {
+      props: {
+        eventDate: '2023-06-20',
+        eventId: 'card-id',
+        eventTitle: 'Event Card Test',
+        eventStartHour: 9,
+        eventEndHour: 9,
+      },
+    });
+
+    expect(wrapper.find('p').text()).toEqual('Event Card Test');
+  });
+
+  it('should render a card displaying the correct hour format', () => {
+    const wrapper = mount(EventCard, {
+      props: {
+        eventDate: '2023-06-20',
+        eventId: 'card-id',
+        eventTitle: 'Event Card Test',
+        eventStartHour: 9,
+        eventEndHour: 9,
+      },
+    });
+
+    expect(wrapper.find('p:nth-child(2)').text()).toEqual('9:00 AM');
+  });
+
+  it('should render a card displaying the correct hour range format', () => {
+    const wrapper = mount(EventCard, {
+      props: {
+        eventDate: '2023-06-20',
+        eventId: 'card-id',
+        eventTitle: 'Event Card Test',
+        eventStartHour: 9,
+        eventEndHour: 15,
+      },
+    });
+
+    expect(wrapper.find('p:nth-child(2)').text()).toEqual('9:00 AM - 3:00 PM');
+  });
+
+  it('should show the event modal after clicking the card', async () => {
+    const wrapper = mount(EventCard, {
+      global: {
+        stubs: {
+          EventModal: true,
+        },
+      },
+      props: {
+        eventDate: '2023-06-20',
+        eventId: 'card-id',
+        eventTitle: 'Event Card Test',
+        eventStartHour: 9,
+        eventEndHour: 15,
+      },
+    });
+
+    expect(wrapper.findComponent(EventModal).exists()).toBe(false);
+
+    await wrapper.trigger('click');
+    expect(wrapper.findComponent(EventModal).exists()).toBe(true);
+  });
+
+  it('should show the edit event modal after clicking the card', async () => {
+    const wrapper = mount(EventCard, {
+      global: {
+        stubs: {
+          EventModal: true,
+        },
+      },
+      props: {
+        eventDate: '2023-06-20',
+        eventId: 'card-id',
+        eventTitle: 'Event Card Test',
+        eventStartHour: 9,
+        eventEndHour: 15,
+      },
+    });
+
+    await wrapper.trigger('click');
+    expect(wrapper.findComponent(EventModal).attributes('edit')).toBe('true');
+  });
+
+  it('should pass the correct data to the edit event modal props', async () => {
+    const wrapper = mount(EventCard, {
+      global: {
+        stubs: {
+          EventModal: true,
+        },
+      },
+      props: {
+        eventDate: '2023-06-20',
+        eventId: 'card-id',
+        eventTitle: 'Event Card Test',
+        eventStartHour: 9,
+        eventEndHour: 15,
+      },
+    });
+
+    const cardProps = Object.keys(wrapper.props()).map(
+      (key) => wrapper.props()[key]
+    );
+
+    await wrapper.trigger('click');
+
+    const modalProps = Object.keys(
+      wrapper.findComponent(EventModal).props()
+    ).map((key) => wrapper.findComponent(EventModal).props()[key]);
+
+    expect(modalProps).toEqual(expect.arrayContaining(cardProps));
+  });
+});

--- a/src/components/atoms/EventCard/EventCard.vue
+++ b/src/components/atoms/EventCard/EventCard.vue
@@ -28,11 +28,11 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch, computed } from 'vue';
+import { ref, computed } from 'vue';
 import { formatHoursRange } from '@/utils/Hours';
 import EventModal from '@/components/atoms/EventModal';
 
-const props = defineProps<{
+const { eventStartHour, eventEndHour } = defineProps<{
   eventDate: string;
   eventId: string;
   eventTitle: string;
@@ -43,11 +43,11 @@ const props = defineProps<{
 const show = ref(false);
 
 const hourRange = computed(() =>
-  formatHoursRange(props.eventStartHour, props.eventEndHour, true)
+  formatHoursRange(eventStartHour, eventEndHour, true)
 );
 
 const isShort = computed(() =>
-  props.eventEndHour - props.eventStartHour < 2 ? true : false
+  eventEndHour - eventStartHour < 2 ? true : false
 );
 </script>
 

--- a/src/components/atoms/EventCard/EventCard.vue
+++ b/src/components/atoms/EventCard/EventCard.vue
@@ -1,6 +1,6 @@
 <template>
   <article
-    class="event-card grid-start flex h-full w-11/12 flex-col items-start justify-start gap-1 overflow-hidden rounded-md border-2 border-l-[6px] border-slate-100 p-1 text-white shadow-md"
+    class="event-card grid-start flex w-11/12 flex-col items-start justify-start gap-1 overflow-hidden rounded-md px-2 py-1 text-white"
     :class="{ 'grid-end': eventEndHour }"
     @click="show = true"
   >
@@ -61,6 +61,8 @@ const isShort = computed(() =>
 }
 
 .event-card {
+  height: calc(100% - 2px);
   background-color: #f5a278;
+  box-shadow: rgba(0, 0, 0, 0.15) 2.4px 2.4px 3.2px;
 }
 </style>

--- a/src/components/atoms/PreviewCard/PreviewCard.vue
+++ b/src/components/atoms/PreviewCard/PreviewCard.vue
@@ -2,11 +2,11 @@
   <div
     class="preview-card pc-position pointer-events-none shadow-md"
     :class="!changeOffset ? 'pc-top' : 'pc-bottom'"
-  ></div>
+  />
 </template>
 
 <script setup lang="ts">
-const { position, height, changeOffset } = defineProps<{
+defineProps<{
   changeOffset: boolean;
   position: number;
   height: number;
@@ -30,7 +30,6 @@ const { position, height, changeOffset } = defineProps<{
 
 .preview-card {
   background-color: rgba(245, 162, 120, 0.15);
-  /* border: 1px solid black; */
   border-radius: 12px;
 }
 </style>

--- a/src/components/molecules/CalendarDay/CalendarDay.vue
+++ b/src/components/molecules/CalendarDay/CalendarDay.vue
@@ -102,12 +102,6 @@ function handleMouseMove(e: MouseEvent) {
   if (!isMouseDown.value) return;
   isDragging.value = true;
 
-  // if (e.offsetX < 0 || e.offsetX > 131) {
-  //   isMouseDown.value = false;
-  //   isDragging.value = false;
-  //   return;
-  // }
-
   currentOffset.value = target.offsetTop;
   offsetDiff = currentOffset.value - initialPosition;
 

--- a/src/components/organisms/Calendar/Calendar.vue
+++ b/src/components/organisms/Calendar/Calendar.vue
@@ -22,7 +22,7 @@ import { useCalendarStore } from '@/stores/calendarStore';
 import { convertWeekDatesToStrings } from '@/utils/Dates';
 
 const store = useCalendarStore();
-const weekDates = computed(() => convertWeekDatesToStrings(store.weekDates));
+const weekDates = computed(() => convertWeekDatesToStrings(store.weekDates!));
 </script>
 
 <style>

--- a/src/components/organisms/Header/Header.vue
+++ b/src/components/organisms/Header/Header.vue
@@ -35,18 +35,18 @@ const showModal = ref(false);
 
 // TODO: Rework this as an external snippet
 let month = computed(() => {
-  const getWeekStart = new Date(store.weekDates[0]).toDateString();
+  const getWeekStart = new Date(store.weekDates![0]).toDateString();
   let shortMonth = getWeekStart.slice(4, 7);
   let year = getWeekStart.slice(-4);
   return `${shortMonth}' ${year}`;
 });
 
 function moveForward() {
-  updateView(moveWeekForward(store.weekDates));
+  updateView(moveWeekForward(store.weekDates!));
 }
 
 function moveBackwards() {
-  updateView(moveWeekBack(store.weekDates));
+  updateView(moveWeekBack(store.weekDates!));
 }
 
 function handleModal() {

--- a/src/components/organisms/Header/Header.vue
+++ b/src/components/organisms/Header/Header.vue
@@ -18,7 +18,12 @@
       @click="handleModal"
       >Add Event</Button
     >
-    <EventModal v-if="showModal" :show="showModal" @close="handleModal" />
+    <EventModal
+      v-if="showModal"
+      :date="todayDate"
+      :show="showModal"
+      @close="handleModal"
+    />
   </div>
 </template>
 
@@ -27,11 +32,12 @@ import { ref, computed } from 'vue';
 import Button from '@/components/molecules/Button';
 import EventModal from '@/components/atoms/EventModal';
 import { useCalendarStore } from '@/stores/calendarStore';
-import { moveWeekBack, moveWeekForward } from '@/utils/Dates';
+import { moveWeekBack, moveWeekForward, getCurrentDate } from '@/utils/Dates';
 
 const store = useCalendarStore();
 const updateView = store.updateWeekDates;
 const showModal = ref(false);
+const todayDate = ref();
 
 // TODO: Rework this as an external snippet
 let month = computed(() => {
@@ -50,6 +56,7 @@ function moveBackwards() {
 }
 
 function handleModal() {
+  todayDate.value = getCurrentDate();
   showModal.value = !showModal.value;
 }
 </script>

--- a/src/components/organisms/Sidebar/Sidebar.vue
+++ b/src/components/organisms/Sidebar/Sidebar.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup></script>
 
 <template>
-  <div></div>
+  <section></section>
 </template>

--- a/src/stores/calendarStore.ts
+++ b/src/stores/calendarStore.ts
@@ -53,8 +53,6 @@ export const useCalendarStore = defineStore('calendar', () => {
         ],
       });
     }
-
-    console.log(calendarEvents.value);
   }
 
   function updateEvent(

--- a/src/stores/calendarStore.ts
+++ b/src/stores/calendarStore.ts
@@ -5,8 +5,8 @@ import { getWeekNumber } from '@/utils/Dates';
 import UniqueIdentifier from '@/utils/UniqueIdentifier';
 
 export const useCalendarStore = defineStore('calendar', () => {
-  const weekDates = ref();
-  const weekNumber = computed(() => getWeekNumber([weekDates.value[0]]));
+  const weekDates = ref<number[]>();
+  const weekNumber = computed(() => getWeekNumber(weekDates.value![0]));
   const calendarEvents = ref<CalendarEvents[]>([]);
   const weekEvents = computed(() => {
     const findWeek = calendarEvents.value.find(
@@ -29,7 +29,7 @@ export const useCalendarStore = defineStore('calendar', () => {
     startHour: number,
     endHour: number
   ) {
-    const weekMatches = weekNumber.value === getWeekNumber([new Date(date)]);
+    const weekMatches = weekNumber.value === getWeekNumber(date);
 
     if (weekMatches && weekEvents.value) {
       weekEvents.value.events.push({
@@ -41,7 +41,7 @@ export const useCalendarStore = defineStore('calendar', () => {
       });
     } else {
       calendarEvents.value.push({
-        weekNumber: getWeekNumber([new Date(date)]),
+        weekNumber: getWeekNumber(date),
         events: [
           {
             id: UniqueIdentifier(),
@@ -53,6 +53,8 @@ export const useCalendarStore = defineStore('calendar', () => {
         ],
       });
     }
+
+    console.log(calendarEvents.value);
   }
 
   function updateEvent(
@@ -85,7 +87,7 @@ export const useCalendarStore = defineStore('calendar', () => {
   }
 
   function moveEvent(event: DayEvent) {
-    const checkWeekNumber = getWeekNumber([new Date(event.date)]);
+    const checkWeekNumber = getWeekNumber(event.date);
     const checkWeekExists = calendarEvents.value.find(
       (week) => week.weekNumber === checkWeekNumber
     );

--- a/src/utils/Dates.ts
+++ b/src/utils/Dates.ts
@@ -17,30 +17,23 @@ export function getWeekDates(days: number = 7) {
 }
 
 /**
- * Outputs the current week number, based on the first element from the `getWeekDates` array.
+ * Outputs the current week number, based on the provided date.
  */
+export function getWeekNumber(date: number | string): number {
+  const dateObj = new Date(date);
+  dateObj.setHours(0, 0, 0, 0); // Set time to 00:00:00 to ensure consistency
 
-export function getWeekNumber(weekDates: Date[]): number {
-  if (weekDates.length === 0) return 0;
+  const firstDayOfYear = new Date(dateObj.getFullYear(), 0, 1);
+  const daysOffset = (firstDayOfYear.getDay() + 6) % 7; // Number of days to adjust the start of the year
 
-  if (weekDates.length === 0) return 0;
-
-  const firstDate = new Date(weekDates[0]);
-  const lastDate = new Date(weekDates[weekDates.length - 1]);
-
-  const firstDayOfYear = new Date(firstDate.getFullYear(), 0, 1);
   const diffInDays = Math.floor(
-    (firstDate.getTime() - firstDayOfYear.getTime()) / (1000 * 60 * 60 * 24)
+    (dateObj.getTime() -
+      firstDayOfYear.getTime() -
+      daysOffset * 24 * 60 * 60 * 1000) /
+      (24 * 60 * 60 * 1000)
   );
 
-  const firstDayOfWeek = (firstDayOfYear.getDay() + 6) % 7; // Adjust Sunday to be the last day of the week
-
-  const weekNumber = Math.ceil((diffInDays - firstDayOfWeek + 1) / 7);
-
-  // Adjust the week number if the last date falls on Sunday
-  if (lastDate.getDay() === 0) {
-    return weekNumber - 1;
-  }
+  const weekNumber = Math.ceil(diffInDays / 7) + 1; // Add 1 to account for Sunday belonging to the next week
 
   return weekNumber;
 }
@@ -48,7 +41,6 @@ export function getWeekNumber(weekDates: Date[]): number {
 /**
  * Moves the current calendar view forward based on the passed week dates
  */
-
 export function moveWeekForward(weekDates: number[]) {
   const nextWeekDates: number[] = [];
   const interval = weekDates.length * 24 * 60 * 60 * 1000;
@@ -60,7 +52,6 @@ export function moveWeekForward(weekDates: number[]) {
 /**
  * Moves the current calendar view back based on the passed week dates
  */
-
 export function moveWeekBack(weekDates: number[]) {
   const previousWeekDates: number[] = [];
   const interval = weekDates.length * 24 * 60 * 60 * 1000;
@@ -70,7 +61,7 @@ export function moveWeekBack(weekDates: number[]) {
 }
 
 /**
- * Converts an array with dates, in miliseconds, to an array with string dates
+ * Converts an array with dates, in miliseconds, to an array with string dates (YYYY-MM-DD)
  */
 export function convertWeekDatesToStrings(datesArray: number[]) {
   return datesArray.map((date) => {

--- a/src/utils/Dates.ts
+++ b/src/utils/Dates.ts
@@ -17,6 +17,18 @@ export function getWeekDates(days: number = 7) {
 }
 
 /**
+ * Outputs the current date as a string Date (YYYY-MM-DD)
+ */
+export function getCurrentDate() {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+/**
  * Outputs the current week number, based on the provided date.
  */
 export function getWeekNumber(date: number | string): number {

--- a/src/utils/Hours.ts
+++ b/src/utils/Hours.ts
@@ -7,7 +7,12 @@ export function formatHoursRange(
 
   const formattedStart = formatHour(startHour);
   const formattedEnd = formatHour(endHour);
-  return `${formattedStart} - ${formattedEnd}`;
+  const formatFinal =
+    formattedStart === formattedEnd
+      ? formattedStart
+      : `${formattedStart} - ${formattedEnd}`;
+
+  return formatFinal;
 }
 
 function formatHour12(hour: number): string {
@@ -23,7 +28,7 @@ function formatHour12(hour: number): string {
     minutes.replace('00', `${formattedMinutes}`);
   }
 
-  return `${formattedHour}:${minutes} ${isAM ? 'am' : 'pm'}`;
+  return `${formattedHour}:${minutes} ${isAM ? 'AM' : 'PM'}`;
 }
 
 function formatHour24(hour: number): string {

--- a/src/views/pages/DefaultLayout/DefaultLayout.vue
+++ b/src/views/pages/DefaultLayout/DefaultLayout.vue
@@ -27,7 +27,7 @@ import Button from '@/components/molecules/Button';
 import IconLoader from '@/components/atoms/IconLoader';
 import { onMounted, onUnmounted, ref } from 'vue';
 
-const sidebarOpen = ref(true);
+const sidebarOpen = ref(false);
 
 function sidebarToggle() {
   sidebarOpen.value = !sidebarOpen.value;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,13 @@ import vue from '@vitejs/plugin-vue';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [
+    vue({
+      script: {
+        propsDestructure: true,
+      },
+    }),
+  ],
   test: {
     globals: true,
     environment: 'happy-dom',


### PR DESCRIPTION
# Description
[comment]: # (Please include a summary of the change and which issue is fixed, if such. Please also include relevant motivation and context. List any dependencies that are required for this change)
[comment]: # (If the PR closes any opened issue, please use 'Fixes #issueID')


## Type of change
[comment]: # (They can be: ✨ Feature | 🐞 Bug | 📙 Documentation | 🧶 Chore | 🧬 Refactor | ⚡ Test | 🌈 Styling | 🔥 Enhancement | 💣 Breaking Change | 📦 Package)

- [x] 🐞 Bug
- [x] 🧶 Chore
- [x] 🧬 Refactor
- [x] 🌈 Styling
- [x] ⚡ Test 

## Changes:
[comment]: # (Place here the more granular changes you've made)

### 🐞 Fixing `getWeekNumber` utility function wrong week output
- Changed the `getWeekNumber` function to output the week number based on the provided date instead of the first day from the `weekDates` array
- Changed the typing the accept either a `number` or a `string`
- Updated the `calendarStore` accordingly to reflect the change
- Updated some of the `Dates` utility functions descriptions

### 🧶 Minor `components` fixes
- Fixed some `TS` errors on the `Header` molecule
- Removed unnecessary `props` destructuring from the `PreviewCard` atom
- Removed commented code on `CalendarDay` molecule

### 🧬 Adding reactive `props` destructure option
- Refactored `EventCard` atom to reflect this addition
- Added a `getCurrentDate` utility function to output current date in the format (YYYY-MM-DD)
- Added a QoL enhancement on the *Add Event* `button`, so the `EventModal` defaults the `Date` field for the current date

### 🌈⚡ Restyling `EventCard` atom and adding `unit tests`
- Changed the default state of the `Sidebar` to be closed
- Removed the `log` from the `calendarStore`
- Slight adjust on the `formatHoursRange` utility function
- Restyled the `EventCard` atom
- Added `unit tests` to the `EventCard` atom

