### PR TITLE
🧬 Better adjusting the `EventDisplay` position

### DIFF
--- a/src/components/atoms/EventCard/EventCard.vue
+++ b/src/components/atoms/EventCard/EventCard.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed } from 'vue';
+import { computed } from 'vue';
 import { formatHoursRange } from '@/utils/Hours';
 
 const { eventStartHour, eventEndHour } = defineProps<{
@@ -27,8 +27,6 @@ const { eventStartHour, eventEndHour } = defineProps<{
   eventStartHour: number;
   eventEndHour: number;
 }>();
-
-const show = ref(false);
 
 const hourRange = computed(() =>
   formatHoursRange(eventStartHour, eventEndHour, true)

--- a/src/components/atoms/EventDisplay/EventDisplay.vue
+++ b/src/components/atoms/EventDisplay/EventDisplay.vue
@@ -2,7 +2,11 @@
   <div
     id="event-display"
     class="absolute h-96 w-64 rounded-md bg-slate-100"
-    :class="{ 'card-right': position === 'right' }"
+    :class="[
+      { 'card-translateX': horizontalPosition === 'right' },
+      { 'card-translateY': translate },
+      { 'card-translate': horizontalPosition === 'right' && translate },
+    ]"
   >
     <Button
       icon="Close"
@@ -28,23 +32,25 @@ import { computed } from 'vue';
 import Button from '@/components/molecules/Button';
 import EventModal from '@/components/atoms/EventModal';
 
-const { offsetTop, offsetLeft, offsetWidth, position } = defineProps<{
-  offsetTop: number;
-  position: string;
-  offsetLeft: number;
-  offsetWidth: number;
-}>();
+const { offsetTop, offsetLeft, offsetWidth, horizontalPosition, translate } =
+  defineProps<{
+    offsetTop: number;
+    offsetLeft: number;
+    offsetWidth: number;
+    horizontalPosition: string;
+    translate: boolean;
+  }>();
 
 const emit = defineEmits<{
   (e: 'close', show: boolean): void;
 }>();
 
 const offsetSum = computed(() => {
-  if (position === 'left') return offsetLeft + offsetWidth;
+  if (horizontalPosition === 'left') return offsetLeft + offsetWidth;
   else return offsetLeft;
 });
 
-const refinedOffsetTop = computed(() => offsetTop - Math.round(offsetTop / 3));
+const refinedOffsetTop = computed(() => offsetTop - 12);
 
 function closeDisplay() {
   emit('close', true);
@@ -57,9 +63,17 @@ function closeDisplay() {
   left: v-bind(offsetSum + 'px');
   box-shadow: rgba(0, 0, 0, 0.4) 0px 2px 4px,
     rgba(0, 0, 0, 0.3) 0px 7px 13px -3px, rgba(0, 0, 0, 0.2) 0px -3px 0px inset;
+  /* transform: translateX(v-bind(translateX), v-bind(translateY)); */
 }
 
-.card-right {
+.card-translateX {
   transform: translateX(-108%);
+}
+.card-translateY {
+  transform: translateY(-100%);
+}
+
+.card-translate {
+  transform: translate(-108%, -100%);
 }
 </style>


### PR DESCRIPTION
# Description
[comment]: # (Please include a summary of the change and which issue is fixed, if such. Please also include relevant motivation and context. List any dependencies that are required for this change)
[comment]: # (If the PR closes any opened issue, please use 'Fixes #issueID')

Improved the `EventDisplay` position relative to the clicked `EventCard`

## Type of change
[comment]: # (They can be: ⭐ Feature | 🐞 Bug | 📙 Documentation | 🧶 Chore | 🧬 Refactor | ⚡ Test | 🌈 Styling | 🔥 Enhancement | 💣 Breaking Change | 📦 Package)

- [x] 🧬 Refactor

## Changes:
[comment]: # (Place here the more granular changes you've made)

- Reworked the `refinedOffsetTop` computed property on the `EventDisplay` card
- Removed `show` ref from the `EventCard` atom (unnecessary)
- Adjusted the `scroll` behaviour for longer events (not an optimal solution)
- Adjusted the `EventDisplay` taking in account the available bottom space (not an optimal solution)