### PR TITLE
🐞 Fixing `drag` position and `hours` display

### DIFF
--- a/src/components/atoms/EventCard/EventCard.vue
+++ b/src/components/atoms/EventCard/EventCard.vue
@@ -28,6 +28,9 @@ const { eventStartHour, eventEndHour } = defineProps<{
   eventEndHour: number;
 }>();
 
+const startHourFix = computed(() => eventStartHour + 1);
+const endHourFix = computed(() => eventEndHour + 1);
+
 const hourRange = computed(() =>
   formatHoursRange(eventStartHour, eventEndHour, true)
 );
@@ -42,10 +45,10 @@ const isShort = computed(() =>
   height: calc(100% - 2px);
   background-color: #f5a278;
   box-shadow: rgba(0, 0, 0, 0.15) 2.4px 2.4px 3.2px;
-  grid-row-start: v-bind('eventStartHour + 1');
+  grid-row-start: v-bind('startHourFix');
 }
 
 .grid-end {
-  grid-row-end: v-bind('eventEndHour + 1');
+  grid-row-end: v-bind('endHourFix');
 }
 </style>

--- a/src/components/molecules/CalendarDay/CalendarDay.vue
+++ b/src/components/molecules/CalendarDay/CalendarDay.vue
@@ -112,11 +112,12 @@ function handleMouseMove(e: MouseEvent) {
     height.value = offsetDiff + 50;
   } else {
     changeOffset.value = true;
-    height.value = Math.abs(offsetDiff);
+    height.value = Math.abs(offsetDiff) + target.offsetHeight;
 
     if (offsetDiff === -50) {
-      const containerHeight = (target.offsetParent! as HTMLElement)
-        .offsetHeight;
+      const containerHeight =
+        (target.offsetParent! as HTMLElement).offsetHeight -
+        target.offsetHeight;
       position.value = containerHeight - target.offsetTop - target.offsetHeight;
     }
   }
@@ -132,7 +133,7 @@ function handleMouseUp(e: MouseEvent) {
   if (offsetDiff >= 0) {
     endHour.value = +target.dataset.hour!;
   } else {
-    endHour.value = startHour.value;
+    endHour.value = startHour.value + 1;
     startHour.value = +target.dataset.hour! - 1;
   }
 

--- a/src/components/molecules/CalendarDay/CalendarDay.vue
+++ b/src/components/molecules/CalendarDay/CalendarDay.vue
@@ -3,14 +3,14 @@
     <CalendarHeader :shortDate="shortDayDate" :dateTime="day" />
     <div
       :id="day"
-      class="calendar-day__grid relative h-full cursor-pointer grid-cols-1 grid-rows-[repeat(24,_minmax(3em,_1fr))] border-r"
+      class="calendar-day relative h-full cursor-pointer grid-cols-1 grid-rows-[repeat(24,_minmax(3em,_1fr))] border-r"
       :class="{ 'border-r-0': index === 6 }"
     >
       <!-- Convert to atom -->
-      <div
+      <time
         v-for="(t, index) in 24"
-        :data-hour="t - 1"
-        class="hour__grid-area relative flex border-b"
+        :data-hour="t"
+        class="day-hour relative flex border-b"
         :class="{ 'border-b-0': index === 23, 'cursor-move': isMouseDown }"
         @click="handleModal"
         @mousedown.prevent="handleMouseDown"
@@ -95,7 +95,7 @@ function handleMouseDown(e: MouseEvent) {
   isMouseDown.value = true;
   position.value = target.offsetTop;
   initialPosition = position.value;
-  startHour.value = +target.dataset.hour!;
+  startHour.value = +target.dataset.hour! - 1;
 }
 
 function handleMouseMove(e: MouseEvent) {
@@ -133,7 +133,7 @@ function handleMouseUp(e: MouseEvent) {
     endHour.value = +target.dataset.hour!;
   } else {
     endHour.value = startHour.value;
-    startHour.value = +target.dataset.hour!;
+    startHour.value = +target.dataset.hour! - 1;
   }
 
   showModal.value = true;
@@ -145,21 +145,11 @@ const events = computed(() =>
 </script>
 
 <style>
-.calendar-day__grid {
+.calendar-day {
   display: grid;
-  grid-template-areas: 'day';
 }
 
-.event__grid-area {
-  grid-row: 1/-1;
-  grid-area: 'day';
-}
-
-.hour__grid-area {
-  grid-area: 'day';
-}
-
-.hour__grid-area:hover {
+.day-hour:hover {
   background-color: rgba(245, 162, 120, 0.4);
 }
 </style>


### PR DESCRIPTION
# Description
[comment]: # (Please include a summary of the change and which issue is fixed, if such. Please also include relevant motivation and context. List any dependencies that are required for this change)
[comment]: # (If the PR closes any opened issue, please use 'Fixes #issueID')

Fixed the incorrect start and end `hours` incorrect display, on `EventModal` and `EventCard` upon `click` or `drag`, as well as the 'reverse' `dragging` cell skip  

## Type of change
[comment]: # (They can be: ⭐ Feature | 🐞 Bug | 📙 Documentation | 🧶 Chore | 🧬 Refactor | ⚡ Test | 🌈 Styling | 🔥 Enhancement | 💣 Breaking Change | 📦 Package)

- [x] 🐞 Bug 

## Changes:
[comment]: # (Place here the more granular changes you've made)
### 🐞 Fixed `EventCard` start and end `hours` incorrect display and position
- Fixed the `EventModal`, both for `click` and `drag` (normal and reverse), displayed `hours` not correctly matching the `EventCard` size
- Fixed the `EventCard` start and end `hours` matching the correct positions on the `grid`
- Removed unnecessary stylings from the `EventCard` molecule

### 🐞 Fixed `PreviewCard` bug on reverse `drag`
- Adjusted the 'reverse' `drag` position using the `target.offsetHeight` to normalize values avoidind the cell skip of the initial `clicked` target
