### PR TITLE
🧬 Reworking the `Calendar` header approach

### DIFF
--- a/src/components/atoms/CalendarHours/CalendarHours.vue
+++ b/src/components/atoms/CalendarHours/CalendarHours.vue
@@ -2,7 +2,6 @@
   <div
     class="grid h-full cursor-pointer grid-cols-1 grid-rows-[repeat(24,_minmax(3em,_1fr))]"
   >
-    <div class="sticky left-0 top-0 h-[4%] px-1"></div>
     <div
       v-for="hour in hours"
       :hour="hour"

--- a/src/components/atoms/EventCard/EventCard.vue
+++ b/src/components/atoms/EventCard/EventCard.vue
@@ -50,8 +50,6 @@ const isShort = computed(() =>
 
 function handleEventCardClick(e: MouseEvent) {
   emit('openEventDisplay', e);
-  console.log(eventCard.value);
-
   if (eventCard.value) eventCard.value.focus();
 }
 </script>

--- a/src/components/atoms/EventDisplay/EventDisplay.vue
+++ b/src/components/atoms/EventDisplay/EventDisplay.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     id="event-display"
-    class="absolute h-64 w-96 rounded-md bg-slate-100"
+    class="absolute z-20 h-64 w-96 overflow-hidden rounded-md bg-slate-100"
     :class="[
       { 'card-translateX': horizontalPosition === 'right' },
       { 'card-translateY': translate },
@@ -76,8 +76,6 @@ const offsetSum = computed(() => {
   else return offsetLeft;
 });
 
-const refinedOffsetTop = computed(() => offsetTop - 12);
-
 function handleEditModal() {
   emit('openEditModal', id!);
   closeDisplay();
@@ -103,7 +101,7 @@ onMounted(() => {
 
 <style>
 #event-display {
-  top: v-bind(refinedOffsetTop + 'px');
+  top: v-bind(offsetTop + 'px');
   left: v-bind(offsetSum + 'px');
   box-shadow: rgba(0, 0, 0, 0.4) 0px 2px 4px,
     rgba(0, 0, 0, 0.3) 0px 7px 13px -3px, rgba(0, 0, 0, 0.2) 0px -3px 0px inset;
@@ -112,6 +110,7 @@ onMounted(() => {
 .card-translateX {
   transform: translateX(-108%);
 }
+
 .card-translateY {
   transform: translateY(-100%);
 }

--- a/src/components/molecules/CalendarDay/CalendarDay.vue
+++ b/src/components/molecules/CalendarDay/CalendarDay.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class="h-full" :data-day="day">
-    <CalendarHeader :shortDate="shortDayDate" :dateTime="day" />
+  <div class="day-z h-full" :data-day="day">
     <div
       :id="day"
       class="calendar-day relative z-[-1] h-full cursor-pointer grid-cols-1 grid-rows-[repeat(24,_minmax(3em,_1fr))] border-r"
@@ -39,11 +38,9 @@
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue';
-import CalendarHeader from '@/components/molecules/CalendarHeader';
 import EventCard from '@/components/atoms/EventCard';
 import PreviewCard from '@/components/atoms/PreviewCard';
 import { useCalendarStore } from '@/stores/calendarStore';
-import { convertDateToShorthand } from '@/utils/Dates';
 
 const { day } = defineProps<{
   day: string;
@@ -62,7 +59,6 @@ const emit = defineEmits<{
 }>();
 
 const store = useCalendarStore();
-const shortDayDate = computed(() => convertDateToShorthand(day));
 const date = ref('');
 const startHour = ref(0);
 const endHour = ref(0);
@@ -107,12 +103,12 @@ function handleMouseMove(e: MouseEvent) {
   if (offsetDiff >= 0) {
     changeOffset.value = false;
     position.value = initialPosition;
-    height.value = offsetDiff + 50;
+    height.value = offsetDiff + 49;
   } else {
     changeOffset.value = true;
     height.value = Math.abs(offsetDiff) + target.offsetHeight;
 
-    if (offsetDiff === -50) {
+    if (offsetDiff === -49 || offsetDiff === -48) {
       const containerHeight =
         (target.offsetParent! as HTMLElement).offsetHeight -
         target.offsetHeight;
@@ -146,6 +142,10 @@ const events = computed(() =>
 <style>
 .calendar-day {
   display: grid;
+}
+
+.day-z {
+  z-index: 0;
 }
 
 .day-hour:hover {

--- a/src/components/molecules/CalendarHeader/CalendarHeader.vue
+++ b/src/components/molecules/CalendarHeader/CalendarHeader.vue
@@ -1,7 +1,5 @@
 <template>
-  <header
-    class="calendar-header sticky left-0 top-0 z-10 h-[4%] place-items-center bg-slate-100"
-  >
+  <header class="calendar-header place-items-center">
     <time :datetime="dateTime" class="text-center text-black">
       {{ shortDate }}
     </time>

--- a/src/components/organisms/Calendar/Calendar.vue
+++ b/src/components/organisms/Calendar/Calendar.vue
@@ -1,41 +1,46 @@
 <template>
-  <div
-    id="calendar"
-    ref="calendar"
-    class="grid grid-cols-8 overflow-x-hidden overflow-y-scroll"
-    v-on="show ? { scroll: handlePositionUpdate } : {}"
-  >
-    <CalendarHours class="z-0" />
-    <CalendarDay
-      class="z-0"
-      v-for="(day, index) in weekDates"
-      :key="day"
-      :day="day"
-      :index="index"
-      @openEventDisplay="handleDisplayCard"
-      @openEventModal="handleModal"
-    />
-    <EventDisplay
-      v-if="show"
-      :id="id"
-      :offsetTop="offsetTop"
-      :offsetLeft="offsetLeft"
-      :offsetWidth="offsetWidth"
-      :horizontalPosition="horizontalPosition"
-      :translate="translateY"
-      @close="show = false"
-      @openEditModal="handleEditModal"
-    />
-    <EventModal
-      v-if="showModal"
-      :show="showModal"
-      :edit="showEditModal"
-      :id="id"
-      :date="date"
-      :startHour="startHour"
-      :endHour="endHour"
-      @close="showModal = false"
-    />
+  <div id="calendar" ref="calendar" class="overflow-x-hidden overflow-y-scroll">
+    <header class="sticky left-0 top-0 z-50 grid grid-cols-8 bg-slate-100 pb-4">
+      <!-- TODO: Rework this -->
+      <div class="px-1" />
+      <CalendarHeader
+        v-for="day in weekDates"
+        :shortDate="convertDateToShorthand(day)"
+        :dateTime="day"
+      />
+    </header>
+    <main class="relative grid grid-cols-8">
+      <CalendarHours />
+      <CalendarDay
+        v-for="(day, index) in weekDates"
+        :key="day"
+        :day="day"
+        :index="index"
+        @openEventDisplay="handleDisplayCard"
+        @openEventModal="handleModal"
+      />
+      <EventDisplay
+        v-if="show"
+        :id="id"
+        :offsetTop="offsetTop"
+        :offsetLeft="offsetLeft"
+        :offsetWidth="offsetWidth"
+        :horizontalPosition="horizontalPosition"
+        :translate="translateY"
+        @close="show = false"
+        @openEditModal="handleEditModal"
+      />
+      <EventModal
+        v-if="showModal"
+        :show="showModal"
+        :edit="showEditModal"
+        :id="id"
+        :date="date"
+        :startHour="startHour"
+        :endHour="endHour"
+        @close="showModal = false"
+      />
+    </main>
   </div>
 </template>
 
@@ -43,10 +48,12 @@
 import { ref, computed, onUpdated } from 'vue';
 import CalendarDay from '@/components/molecules/CalendarDay';
 import CalendarHours from '@/components/atoms/CalendarHours';
+import CalendarHeader from '@/components/molecules/CalendarHeader';
 import EventDisplay from '@/components/atoms/EventDisplay';
 import EventModal from '@/components/atoms/EventModal';
 import { useCalendarStore } from '@/stores/calendarStore';
 import { convertWeekDatesToStrings } from '@/utils/Dates';
+import { convertDateToShorthand } from '@/utils/Dates';
 
 interface modalEmit {
   event: MouseEvent;
@@ -55,6 +62,7 @@ interface modalEmit {
 }
 
 const store = useCalendarStore();
+// const shortDayDate = computed(() => convertDateToShorthand(day));
 const weekDates = computed(() => convertWeekDatesToStrings(store.weekDates!));
 
 const show = ref(false);
@@ -121,7 +129,7 @@ function handleDisplayCard(e?: MouseEvent) {
 
   // 'Waiting' for `scrollIntoView` to finish before calculating offsets. Avoids misplacements
   setTimeout(() => {
-    offsetTop.value = target.getBoundingClientRect().top;
+    offsetTop.value = target.offsetTop;
     offsetLeft.value = parentTarget.offsetLeft;
     offsetWidth.value = parentTarget.offsetWidth;
 
@@ -134,7 +142,7 @@ function handleDisplayCard(e?: MouseEvent) {
 
     // Placing the preview taking in account the available bottom space
     if (gridRowStart >= 18) {
-      offsetTop.value = target.getBoundingClientRect().bottom;
+      offsetTop.value = target!.offsetTop + target!.offsetHeight;
       translateY.value = true;
     } else {
       translateY.value = false;
@@ -159,10 +167,11 @@ function updateDisplayCardPosition(targetEl?: HTMLElement) {
   const gridRowStart = +styles.getPropertyValue('grid-row-start');
 
   if (gridRowStart >= 18) {
-    offsetTop.value = targetEl!.getBoundingClientRect().bottom;
+    offsetTop.value = targetEl!.offsetTop + targetEl!.offsetHeight;
   } else {
-    offsetTop.value = targetEl!.getBoundingClientRect().top;
+    offsetTop.value = targetEl!.offsetTop;
   }
+
   offsetLeft.value = parentTarget.offsetLeft;
   offsetWidth.value = parentTarget.offsetWidth;
 }
@@ -181,6 +190,11 @@ onUpdated(() => {
 </script>
 
 <style>
+#calendar {
+  display: grid;
+  grid-template-rows: minmax(0, 50px) minmax(0, 1fr);
+}
+
 #calendar::-webkit-scrollbar {
   width: 18px;
   background-color: theme('backgroundColor.slate.200');
@@ -189,17 +203,7 @@ onUpdated(() => {
 }
 
 #calendar::-webkit-scrollbar-thumb {
-  background: linear-gradient(
-    45deg,
-    #f5a278 20%,
-    #f9c7ae 20%,
-    #f9c7ae 40%,
-    #f5a278 40%,
-    #f5a278 60%,
-    #f9c7ae 60%,
-    #f9c7ae 80%,
-    #f5a278 80%
-  );
+  background: #f5a278;
   border-radius: 50px;
   border: 6px solid theme('borderColor.slate.200');
 }

--- a/src/components/templates/ModalTemplate/ModalTemplate.vue
+++ b/src/components/templates/ModalTemplate/ModalTemplate.vue
@@ -4,7 +4,7 @@
       id="modal"
       :open="show"
       ref="trapRef"
-      class="absolute left-0 top-0 z-10 flex h-full w-full items-center justify-center"
+      class="absolute left-0 top-0 z-50 flex h-full w-full items-center justify-center"
       @keydown.esc.exact="closeModal"
       @click.self="closeModal"
     >


### PR DESCRIPTION
# Description
[comment]: # (Please include a summary of the change and which issue is fixed, if such. Please also include relevant motivation and context. List any dependencies that are required for this change)
[comment]: # (If the PR closes any opened issue, please use 'Fixes #issueID')

Reworked the `Calendar` header to have a finer control over the `components` stacking context and updated where needed

## Type of change
[comment]: # (They can be: ⭐ Feature | 🐞 Bug | 📙 Documentation | 🧶 Chore | 🧬 Refactor | ⚡ Test | 🌈 Styling | 🔥 Enhancement | 💣 Breaking Change | 📦 Package)

- [x] 🧬 Refactor 

## Changes:
[comment]: # (Place here the more granular changes you've made)

- Adjusted the `z-index` property on the `ModalTemplate` template
- Removed the `CalendarHeader` from the `CalendarDay` and placed it on the same level as that component
- Removed a *placeholder* `div` from `CalendarHours` and placed it on the `Calendar` organism the same level as `Calendarheader` and `CalendarDay`
- Reworked the `Calendar` organism grid
- Simplified the `scrollbar` styling
- Removed the conditional `EventListener` for the `scroll` when the `EventDisplay` is showing (unnecessary)
- Adjusted reverse `dragging` calculations