### PR TITLE
🌈 Improving `EventModal` stylings for `focus` & `error`

### DIFF
--- a/src/components/atoms/InputDate/InputDate.vue
+++ b/src/components/atoms/InputDate/InputDate.vue
@@ -10,7 +10,7 @@
       ref="dateRef"
       type="date"
       placeholder="Insert a date"
-      class="date-input tex-md relative w-full rounded-t-md bg-slate-100 p-1 outline-none focus:bg-slate-200"
+      class="date-input tex-md relative w-full rounded-t-md bg-transparent p-1 outline-none focus:bg-slate-200"
       :value="date"
       @input="handleEmit($event)"
       @change="isFieldValid(date)"
@@ -21,7 +21,7 @@
       v-else
       type="text"
       placeholder="Insert a date"
-      class="text-md w-full border-b-2 border-b-transparent bg-slate-100 p-1 outline-none rounded-t-md"
+      class="text-md w-full border-b-2 border-b-transparent bg-transparent p-1 outline-none rounded-t-md"
       :value="convertDateToShortForm(date)"
       @focusin="focusIn"
     />
@@ -91,6 +91,10 @@ onUpdated(() => {
   background: linear-gradient(120deg, #f5788d, #f5e178, #f5788d);
   background-size: 300% 300%;
   animation: gradient-animation 4s ease-in-out infinite;
+}
+
+label:has(p) .date-input:focus::before {
+  content: none;
 }
 
 @keyframes gradient-animation {

--- a/src/components/atoms/InputHour/InputHour.vue
+++ b/src/components/atoms/InputHour/InputHour.vue
@@ -11,7 +11,7 @@
       :min="min || 0"
       :max="!minHour ? 23 : 24"
       :placeholder="placeholder"
-      class="hour-input w-full rounded-t-md bg-slate-100 p-1 outline-none focus:bg-slate-200"
+      class="hour-input w-full rounded-t-md p-1 outline-none focus:bg-slate-200 bg-transparent"
       :value="hour"
       @input="handleEmit($event)"
       @change="isFieldValid(hour)"
@@ -22,7 +22,7 @@
       v-else
       type="text"
       placeholder="Insert a date"
-      class="text-md w-full border-b-2 border-b-transparent bg-slate-100 p-1 outline-none rounded-t-md"
+      class="text-md w-full border-b-2 border-b-transparent bg-transparent p-1 outline-none rounded-t-md"
       :value="formatHour"
       @focusin="focusIn"
     />
@@ -142,6 +142,10 @@ onUpdated(() => {
   background: linear-gradient(120deg, #f5788d, #f5e178, #f5788d);
   background-size: 300% 300%;
   animation: gradient-animation 4s ease-in-out infinite;
+}
+
+.hour-label:has(.hour-input:focus + p)::before {
+  content: none;
 }
 
 @keyframes gradient-animation {

--- a/src/components/atoms/InputTitle/InputTitle.vue
+++ b/src/components/atoms/InputTitle/InputTitle.vue
@@ -9,7 +9,7 @@
       ref="titleRef"
       type="text"
       placeholder="Add a title"
-      class="title-input w-full rounded-t-md bg-slate-100 p-1 outline-none focus:bg-slate-200"
+      class="title-input w-full rounded-t-md bg-transparent p-1 outline-none focus:bg-slate-200"
       :value="title"
       @input="handleEmit($event)"
       @focusout="isFieldValid"
@@ -65,6 +65,10 @@ function handleEmit(event: Event) {
   background: linear-gradient(120deg, #f5788d, #f5e178, #f5788d);
   background-size: 300% 300%;
   animation: gradient-animation 4s ease-in-out infinite;
+}
+
+.title-label:has(.title-input:focus + p)::before {
+  content: none !important;
 }
 
 @keyframes gradient-animation {


### PR DESCRIPTION
# Description
[comment]: # (Please include a summary of the change and which issue is fixed, if such. Please also include relevant motivation and context. List any dependencies that are required for this change)
[comment]: # (If the PR closes any opened issue, please use 'Fixes #issueID')

Improved the styling overlap if the form field is both being focused and showing an error

## Type of change
[comment]: # (They can be: ⭐ Feature | 🐞 Bug | 📙 Documentation | 🧶 Chore | 🧬 Refactor | ⚡ Test | 🌈 Styling | 🔥 Enhancement | 💣 Breaking Change | 📦 Package)

- [x] 🌈 Styling 

## Changes:
[comment]: # (Place here the more granular changes you've made)

- Changed the background of the `EventModal` form fields to `transparent`
- Changed the styling of the form field to not display the `focus` styling and only the `error` styling, if one of the latter was being shown