### PR TITLE
🐞 Fix `button` not being `disabled` on form field error

### DIFF
--- a/src/components/atoms/EventModal/EventModal.vue
+++ b/src/components/atoms/EventModal/EventModal.vue
@@ -17,12 +17,14 @@
           ref="startHourInput"
           v-model:startHour="eventStartHour"
           @update:startHour="onStartChange"
+          @invalidField="errorCheck"
         />
         <InputHour
           ref="endHourInput"
           v-model:endHour="eventEndHour"
           @update:endHour="onEndChange"
           :minHour="eventStartHour || 0"
+          @invalidField="errorCheck"
         />
       </div>
     </form>
@@ -50,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted, reactive, ref } from 'vue';
 import ModalTemplate from '@/components/templates/ModalTemplate';
 import Button from '@/components/molecules/Button';
 import InputDate from '@/components/atoms/InputDate';
@@ -82,6 +84,12 @@ const eventTitle = ref(title || '');
 const eventDate = ref(date || '');
 const eventStartHour = ref(startHour);
 const eventEndHour = ref(endHour || 0);
+const errorObject = reactive({
+  title: false,
+  date: false,
+  startHour: false,
+  endHour: false,
+});
 
 onMounted(() => {
   if (id) {
@@ -106,8 +114,16 @@ function onEndChange(value: number) {
   else eventEndHour.value = value;
 }
 
-function errorCheck(status: boolean) {
-  error.value = status;
+function errorCheck(
+  value: Partial<{ [key in keyof typeof errorObject]: boolean }>,
+) {
+  const obKey = Object.keys(value)[0] as keyof typeof errorObject;
+  const keyValue: boolean = Object.values(value)[0];
+
+  errorObject[obKey] = keyValue;
+
+  if (Object.values(errorObject).some((value) => value)) error.value = true;
+  else error.value = false;
 }
 
 function addEvent() {

--- a/src/components/atoms/InputDate/InputDate.vue
+++ b/src/components/atoms/InputDate/InputDate.vue
@@ -41,7 +41,7 @@ const { date } = defineProps<{
 
 const emit = defineEmits<{
   (e: 'update:date', value: string): void;
-  (e: 'invalidField', value: boolean): void;
+  (e: 'invalidField', value: { date: boolean }): void;
 }>();
 
 const focus = ref(false);
@@ -57,7 +57,7 @@ function isFieldValid(date: string) {
     error.value = false;
   }
 
-  emit('invalidField', error.value);
+  emit('invalidField', { date: error.value });
 }
 
 function handleEmit(event: Event) {

--- a/src/components/atoms/InputHour/InputHour.vue
+++ b/src/components/atoms/InputHour/InputHour.vue
@@ -48,7 +48,8 @@ const { startHour, endHour, minHour } = defineProps<{
 const emit = defineEmits<{
   (e: 'update:startHour', value: number): void;
   (e: 'update:endHour', value: number): void;
-  (e: 'invalidField', value: boolean): void;
+  (e: 'invalidField', value: { startHour: boolean }): void;
+  (e: 'invalidField', value: { endHour: boolean }): void;
 }>();
 
 const hourRef = ref<HTMLInputElement | null>(null);
@@ -115,7 +116,13 @@ function isFieldValid(hour: number) {
     error.value = false;
   }
 
-  emit('invalidField', error.value);
+  if (startHour) {
+    emit('invalidField', { startHour: error.value });
+  }
+
+  if (endHour) {
+    emit('invalidField', { endHour: error.value });
+  }
 }
 
 function handleEmit(event: Event) {

--- a/src/components/atoms/InputTitle/InputTitle.vue
+++ b/src/components/atoms/InputTitle/InputTitle.vue
@@ -30,7 +30,7 @@ const { title } = defineProps<{
 
 const emit = defineEmits<{
   (e: 'update:title', value: string): void;
-  (e: 'invalidField', value: boolean): void;
+  (e: 'invalidField', value: { title: boolean }): void;
 }>();
 
 const error = ref(false);
@@ -42,7 +42,7 @@ function isFieldValid() {
     error.value = false;
   }
 
-  emit('invalidField', error.value);
+  emit('invalidField', { title: error.value });
 }
 
 function handleEmit(event: Event) {


### PR DESCRIPTION
# Description
[comment]: # (Please include a summary of the change and which issue is fixed, if such. Please also include relevant motivation and context. List any dependencies that are required for this change)
[comment]: # (If the PR closes any opened issue, please use 'Fixes #issueID')

The `errorCheck` function was not handling the error status correctly. If two fields, on the `EventModal` component, were showing errors and one of them was properly filled the submit `button` would be clickable again. This fixes that behaviour.

## Type of change
[comment]: # (They can be: ⭐ Feature | 🐞 Bug | 📙 Documentation | 🧶 Chore | 🧬 Refactor | ⚡ Test | 🌈 Styling | 🔥 Enhancement | 💣 Breaking Change | 📦 Package)

- [x] 🐞 Bug 

## Changes:
[comment]: # (Place here the more granular changes you've made)
- Defined proper `emits` on `InputTitle`, `InputDate` and `InputHour`
- Listened for the `emits` on the `EventModal` component
- Completely refactored the `errorCheck` function handling of error status