### PR TITLE
🔥 Improving `EventModal` & `EventDisplay` communication between `Header` and `Calendar` components

### DIFF
--- a/src/components/organisms/Calendar/Calendar.vue
+++ b/src/components/organisms/Calendar/Calendar.vue
@@ -27,7 +27,7 @@
         :offsetWidth="offsetWidth"
         :horizontalPosition="horizontalPosition"
         :translate="translateY"
-        @close="show = false"
+        @close="handleClosePreview"
         @openEditModal="handleEditModal"
       />
       <EventModal
@@ -64,13 +64,15 @@ interface modalEmit {
   endHour: number;
 }
 
-const { isSidebarOpen, modalStatus } = defineProps<{
-  modalStatus?: boolean;
+const { isSidebarOpen, modalStatus, previewStatus } = defineProps<{
   isSidebarOpen: boolean;
+  modalStatus?: boolean;
+  previewStatus?: boolean;
 }>();
 
 const emit = defineEmits<{
   (e: 'update:modalStatus', value: boolean): void;
+  (e: 'update:previewStatus', value: boolean): void;
 }>();
 
 const store = useCalendarStore();
@@ -100,6 +102,11 @@ function handleEditModal(eventId: string) {
 function handleCloseModal() {
   emit('update:modalStatus', false);
   showModal.value = false;
+}
+
+function handleClosePreview() {
+  emit('update:previewStatus', false);
+  show.value = false;
 }
 
 function handleModal(emitted: modalEmit) {
@@ -172,7 +179,10 @@ function handleDisplayCard(e?: MouseEvent) {
 
     horizontalPosition.value = verdict;
 
-    if (!show.value) show.value = true;
+    if (!show.value) {
+      show.value = true;
+      emit('update:previewStatus', true);
+    }
   }, 450);
 }
 
@@ -214,7 +224,7 @@ watch(
   },
 );
 
-// TODO: Add this into a single watcher
+// TODO: Add these into a single watcher
 watch(
   () => modalStatus,
   () => {
@@ -224,6 +234,14 @@ watch(
       endHour.value = undefined;
       showModal.value = true;
     }
+  },
+);
+
+watch(
+  () => previewStatus,
+  () => {
+    if (previewStatus) show.value = true;
+    else show.value = previewStatus;
   },
 );
 </script>

--- a/src/components/organisms/Calendar/Calendar.vue
+++ b/src/components/organisms/Calendar/Calendar.vue
@@ -38,7 +38,7 @@
         :date="date"
         :startHour="startHour"
         :endHour="endHour"
-        @close="showModal = false"
+        @close="handleCloseModal"
       />
     </main>
   </div>
@@ -52,8 +52,11 @@ import CalendarHeader from '@/components/molecules/CalendarHeader';
 import EventDisplay from '@/components/atoms/EventDisplay';
 import EventModal from '@/components/atoms/EventModal';
 import { useCalendarStore } from '@/stores/calendarStore';
-import { convertWeekDatesToStrings } from '@/utils/Dates';
-import { convertDateToShorthand } from '@/utils/Dates';
+import {
+  convertWeekDatesToStrings,
+  convertDateToShorthand,
+  getCurrentDate,
+} from '@/utils/Dates';
 
 interface modalEmit {
   event: MouseEvent;
@@ -61,8 +64,13 @@ interface modalEmit {
   endHour: number;
 }
 
-const { isSidebarOpen } = defineProps<{
+const { isSidebarOpen, modalStatus } = defineProps<{
+  modalStatus?: boolean;
   isSidebarOpen: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modalStatus', value: boolean): void;
 }>();
 
 const store = useCalendarStore();
@@ -80,13 +88,18 @@ const horizontalPosition = ref('');
 const translateY = ref(false);
 const id = ref();
 const date = ref();
-const startHour = ref(0);
-const endHour = ref(0);
+const startHour = ref<number | undefined>(0);
+const endHour = ref<number | undefined>(0);
 
 function handleEditModal(eventId: string) {
   id.value = eventId;
   showEditModal.value = true;
   showModal.value = true;
+}
+
+function handleCloseModal() {
+  emit('update:modalStatus', false);
+  showModal.value = false;
 }
 
 function handleModal(emitted: modalEmit) {
@@ -198,7 +211,20 @@ watch(
     setTimeout(() => {
       handlePositionUpdate();
     }, 300);
-  }
+  },
+);
+
+// TODO: Add this into a single watcher
+watch(
+  () => modalStatus,
+  () => {
+    if (modalStatus) {
+      date.value = getCurrentDate();
+      startHour.value = undefined;
+      endHour.value = undefined;
+      showModal.value = true;
+    }
+  },
 );
 </script>
 

--- a/src/components/organisms/Header/Header.vue
+++ b/src/components/organisms/Header/Header.vue
@@ -18,28 +18,24 @@
     <Button
       class="rounded-lg bg-slate-100 px-6 py-2 font-bold text-black active:translate-y-[1px]"
       @click="handleModal"
-      >Add Event</Button
     >
-    <EventModal
-      v-if="showModal"
-      :date="todayDate"
-      :show="showModal"
-      @close="handleModal"
-    />
+      Add Event
+    </Button>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { computed } from 'vue';
 import Button from '@/components/molecules/Button';
-import EventModal from '@/components/atoms/EventModal';
 import { useCalendarStore } from '@/stores/calendarStore';
-import { moveWeekBack, moveWeekForward, getCurrentDate } from '@/utils/Dates';
+import { moveWeekBack, moveWeekForward } from '@/utils/Dates';
+
+const emit = defineEmits<{
+  (e: 'modalStatus', value: boolean): void;
+}>();
 
 const store = useCalendarStore();
 const updateView = store.updateWeekDates;
-const showModal = ref(false);
-const todayDate = ref();
 
 // TODO: Rework this as an external snippet
 let month = computed(() => {
@@ -58,7 +54,6 @@ function moveBackwards() {
 }
 
 function handleModal() {
-  todayDate.value = getCurrentDate();
-  showModal.value = !showModal.value;
+  emit('modalStatus', true);
 }
 </script>

--- a/src/components/organisms/Header/Header.vue
+++ b/src/components/organisms/Header/Header.vue
@@ -32,6 +32,7 @@ import { moveWeekBack, moveWeekForward } from '@/utils/Dates';
 
 const emit = defineEmits<{
   (e: 'modalStatus', value: boolean): void;
+  (e: 'previewStatus', value: boolean): void;
 }>();
 
 const store = useCalendarStore();
@@ -46,10 +47,12 @@ let month = computed(() => {
 });
 
 function moveForward() {
+  emit('previewStatus', false);
   updateView(moveWeekForward(store.weekDates!));
 }
 
 function moveBackwards() {
+  emit('previewStatus', false);
   updateView(moveWeekBack(store.weekDates!));
 }
 

--- a/src/views/pages/DefaultLayout/DefaultLayout.vue
+++ b/src/views/pages/DefaultLayout/DefaultLayout.vue
@@ -9,11 +9,16 @@
       id="view"
       class="relative m-3 flex flex-col gap-4 overflow-hidden rounded-lg bg-slate-100"
     >
-      <Header @modalStatus="handleHeaderModal" />
+      <Header
+        @modalStatus="handleHeaderModal"
+        @previewStatus="handleHeaderPreview"
+      />
       <Calendar
         :isSidebarOpen="sidebarOpen"
         :modalStatus="modalOpen"
+        :previewStatus="previewOpen"
         @update:modalStatus="handleHeaderModal"
+        @update:previewStatus="handleHeaderPreview"
       />
       <Button class="absolute left-1 top-1 h-6 w-6" @click="sidebarToggle()">
         <IconLoader v-if="sidebarOpen" name="SidebarCollapse" />
@@ -33,6 +38,7 @@ import { onMounted, onUnmounted, ref } from 'vue';
 
 const sidebarOpen = ref(false);
 const modalOpen = ref(false);
+const previewOpen = ref(false);
 
 function sidebarToggle() {
   sidebarOpen.value = !sidebarOpen.value;
@@ -40,6 +46,10 @@ function sidebarToggle() {
 
 function handleHeaderModal(value: boolean) {
   modalOpen.value = value;
+}
+
+function handleHeaderPreview(value: boolean) {
+  previewOpen.value = value;
 }
 
 //////////////////////

--- a/src/views/pages/DefaultLayout/DefaultLayout.vue
+++ b/src/views/pages/DefaultLayout/DefaultLayout.vue
@@ -9,8 +9,12 @@
       id="view"
       class="relative m-3 flex flex-col gap-4 overflow-hidden rounded-lg bg-slate-100"
     >
-      <Header />
-      <Calendar :isSidebarOpen="sidebarOpen" />
+      <Header @modalStatus="handleHeaderModal" />
+      <Calendar
+        :isSidebarOpen="sidebarOpen"
+        :modalStatus="modalOpen"
+        @update:modalStatus="handleHeaderModal"
+      />
       <Button class="absolute left-1 top-1 h-6 w-6" @click="sidebarToggle()">
         <IconLoader v-if="sidebarOpen" name="SidebarCollapse" />
         <IconLoader v-else name="SidebarExpand" />
@@ -28,9 +32,14 @@ import IconLoader from '@/components/atoms/IconLoader';
 import { onMounted, onUnmounted, ref } from 'vue';
 
 const sidebarOpen = ref(false);
+const modalOpen = ref(false);
 
 function sidebarToggle() {
   sidebarOpen.value = !sidebarOpen.value;
+}
+
+function handleHeaderModal(value: boolean) {
+  modalOpen.value = value;
 }
 
 //////////////////////


### PR DESCRIPTION
# Description
[comment]: # (Please include a summary of the change and which issue is fixed, if such. Please also include relevant motivation and context. List any dependencies that are required for this change)
[comment]: # (If the PR closes any opened issue, please use 'Fixes #issueID')

Centralized control over the `EventModal` behaviour on the `Calendar` component, and implemented the `EventDisplay` closing, if currently showing, when the week view is changed.

## Type of change
[comment]: # (They can be: ⭐ Feature | 🐞 Bug | 📙 Documentation | 🧶 Chore | 🧬 Refactor | ⚡ Test | 🌈 Styling | 🔥 Enhancement | 💣 Breaking Change | 📦 Package)

- [x] 🔥 Enhancement 

## Changes:
[comment]: # (Place here the more granular changes you've made)

🔥 Improving `EventModal` communication between `Header` and `Calendar` components

- Deleted the `EventModal` component from the `Header` component (unnecessary)
- Defined `emits` between the `Calendar` and `Header` components to handle the `EventModal` behaviour 
- Redefined `TypeScript` types of `startHour` and `endHour` refs from the `Calendar` component

___

🔥 Improving `EventDisplay` communication between `Header` and `Calendar` components

- Defined `emits` between the `Calendar` and `Header` components to handle the `EventDisplay` behaviour 