### PR TITLE
🐞 Fix event title auto-fill when using `Add Event` button

### DIFF
--- a/src/components/organisms/Calendar/Calendar.vue
+++ b/src/components/organisms/Calendar/Calendar.vue
@@ -230,6 +230,7 @@ watch(
   () => {
     if (modalStatus) {
       date.value = getCurrentDate();
+      id.value = '';
       startHour.value = undefined;
       endHour.value = undefined;
       showModal.value = true;


### PR DESCRIPTION
# Description
[comment]: # (Please include a summary of the change and which issue is fixed, if such. Please also include relevant motivation and context. List any dependencies that are required for this change)
[comment]: # (If the PR closes any opened issue, please use 'Fixes #issueID')

After clicking the `EventDisplay` the event title would be auto-filled since the `id` was not being properly reset. Implemented an `id` reset on the responsible watcher from the `Calendar` component .

## Type of change
[comment]: # (They can be: ⭐ Feature | 🐞 Bug | 📙 Documentation | 🧶 Chore | 🧬 Refactor | ⚡ Test | 🌈 Styling | 🔥 Enhancement | 💣 Breaking Change | 📦 Package)

- [x] 🐞 Bug

## Changes:
[comment]: # (Place here the more granular changes you've made)

- Implemented an `id` reset on the `modalStatus` watcher from the `Calendar` component