### PR TITLE
🧬 Creating `GlobalModalTemplate` and `PositionedModalTemplate` templates

### DIFF
--- a/src/components/atoms/EventDisplay/EventDisplay.vue
+++ b/src/components/atoms/EventDisplay/EventDisplay.vue
@@ -1,5 +1,6 @@
 <template>
-  <div
+  <PositionedModalTemplate
+    focusOnElement="button"
     id="event-display"
     class="absolute z-20 h-max w-96 overflow-hidden rounded-md bg-slate-100"
     :class="[
@@ -7,57 +8,59 @@
       { 'card-translateY': translate },
       { 'card-translate': horizontalPosition === 'right' && translate },
     ]"
+    @close="emit('close', true)"
   >
-    <header class="flex justify-end gap-2 bg-[#f5e178] p-1">
-      <Button
-        icon="Edit"
-        :size="20"
-        class="display-button relative z-10 rounded-md p-[2px] text-[#F5788D] hover:text-white"
-        @click.prevent="handleEditModal"
-      />
-      <Button
-        icon="Trash"
-        :size="20"
-        class="display-button relative z-10 rounded-md p-[2px] text-[#F5788D] hover:text-white"
-        @click.prevent="handleDelete"
-      />
-      <Button
-        icon="Close"
-        :size="20"
-        class="display-button relative z-10 rounded-md p-[2px] text-[#F5788D] hover:text-white"
-        @click.pevent="closeDisplay"
-      />
-    </header>
-    <main class="flex flex-col gap-6 p-4">
-      <section class="flex flex-col gap-2">
-        <h2 class="text-lg font-semibold">{{ title }}</h2>
-        <div class="flex justify-start gap-8 text-sm text-gray-500">
-          <span class="flex items-center gap-2">
-            <IconLoader name="Calendar" :size="14" class="text-gray-400" />
-            <p>{{ parsedDate }}</p>
-          </span>
-          <span class="flex items-center gap-2">
-            <IconLoader name="Clock" :size="14" class="text-gray-400" />
-            <p>{{ hourRange }}</p>
-          </span>
-        </div>
-      </section>
-      <hr />
-      <section class="flex flex-col gap-2">
-        <h2 class="text-lg font-semibold">Description</h2>
-        <p class="text-sm text-gray-500">
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Officiis aut
-          placeat quos ex numquam sed dolores facilis atque exercitationem,
-          corporis ipsum magnam aperiam! Ullam sint praesentium sit architecto
-          suscipit vitae?
-        </p>
-      </section>
-    </main>
-  </div>
+    <template #header>
+      <header class="flex justify-end gap-2 bg-[#f5e178] p-1">
+        <Button
+          icon="Edit"
+          :size="20"
+          class="display-button relative z-10 rounded-md p-[2px] text-[#F5788D] hover:text-white focus-visible:text-white outline-none"
+          @click.prevent="handleEditModal"
+        />
+        <Button
+          icon="Trash"
+          :size="20"
+          class="display-button relative z-10 rounded-md p-[2px] text-[#F5788D] hover:text-white focus-visible:text-white outline-none"
+          @click.prevent="handleDelete"
+        />
+        <Button
+          icon="Close"
+          :size="20"
+          class="display-button relative z-10 rounded-md p-[2px] text-[#F5788D] hover:text-white focus-visible:text-white outline-none"
+          @click.pevent="closeDisplay"
+        />
+      </header>
+    </template>
+    <section class="flex flex-col gap-2">
+      <h2 class="text-lg font-semibold">{{ title }}</h2>
+      <div class="flex justify-start gap-8 text-sm text-gray-500">
+        <span class="flex items-center gap-2">
+          <IconLoader name="Calendar" :size="14" class="text-gray-400" />
+          <p>{{ parsedDate }}</p>
+        </span>
+        <span class="flex items-center gap-2">
+          <IconLoader name="Clock" :size="14" class="text-gray-400" />
+          <p>{{ hourRange }}</p>
+        </span>
+      </div>
+    </section>
+    <hr />
+    <section class="flex flex-col gap-2">
+      <h2 class="text-lg font-semibold">Description</h2>
+      <p class="text-sm text-gray-500">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Officiis aut
+        placeat quos ex numquam sed dolores facilis atque exercitationem,
+        corporis ipsum magnam aperiam! Ullam sint praesentium sit architecto
+        suscipit vitae?
+      </p>
+    </section>
+  </PositionedModalTemplate>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
+import PositionedModalTemplate from '@/components/templates/PositionedModalTemplate';
 import Button from '@/components/molecules/Button';
 import IconLoader from '@/components/atoms/IconLoader';
 import { useCalendarStore } from '@/stores/calendarStore';
@@ -100,7 +103,7 @@ const offsetSum = computed(() => {
 });
 
 const hourRange = computed(() =>
-  formatHoursRange(startHour.value, endHour.value, true)
+  formatHoursRange(startHour.value, endHour.value, true),
 );
 
 const parsedDate = computed(() => convertDateToShortForm(date.value));
@@ -148,7 +151,8 @@ onMounted(() => {
   transform: translate(-108%, -100%);
 }
 
-.display-button:hover::before {
+.display-button:hover::before,
+.display-button:focus-visible::before {
   content: '';
   position: absolute;
   top: 50%;

--- a/src/components/atoms/EventModal/EventModal.vue
+++ b/src/components/atoms/EventModal/EventModal.vue
@@ -1,5 +1,9 @@
 <template>
-  <ModalTemplate :show="show" @close="emit('close', true)">
+  <GlobalModalTemplate
+    :show="show"
+    focusOnElement="input"
+    @close="emit('close', true)"
+  >
     <form class="flex flex-col gap-3" ref="formValidation" id="event-form">
       <InputTitle
         ref="titleInput"
@@ -48,12 +52,12 @@
         Create
       </Button>
     </template>
-  </ModalTemplate>
+  </GlobalModalTemplate>
 </template>
 
 <script setup lang="ts">
 import { onMounted, reactive, ref } from 'vue';
-import ModalTemplate from '@/components/templates/ModalTemplate';
+import GlobalModalTemplate from '@/components/templates/GlobalModalTemplate';
 import Button from '@/components/molecules/Button';
 import InputDate from '@/components/atoms/InputDate';
 import InputTitle from '@/components/atoms/InputTitle';
@@ -153,3 +157,4 @@ function editEvent(id: string) {
   }
 }
 </script>
+@/components/templates/GlobalModalTemplate

--- a/src/components/templates/GlobalModalTemplate/GlobalModalTemplate.vue
+++ b/src/components/templates/GlobalModalTemplate/GlobalModalTemplate.vue
@@ -3,12 +3,11 @@
     <dialog
       id="modal"
       :open="show"
-      ref="trapRef"
       class="absolute left-0 top-0 z-50 flex h-full w-full flex-col items-center justify-center"
       @keydown.esc.exact="closeModal"
       @click.self="closeModal"
     >
-      <div class="w-1/3 rounded-xl bg-slate-100">
+      <div class="w-1/3 rounded-xl bg-slate-100" ref="trapRef">
         <header class="relative h-10 w-full rounded-t-xl bg-[#f5e178]" />
 
         <main class="flex w-full flex-col gap-8 p-4" ref="modalContainer">
@@ -33,9 +32,9 @@ import { onMounted, ref } from 'vue';
 import useFocusTrap from '@/composables/useFocusTrap';
 import Button from '@/components/molecules/Button';
 
-const { show } = defineProps<{
+const { show, focusOnElement } = defineProps<{
   show: boolean;
-  errorMessage?: string;
+  focusOnElement: string;
   attachTo?: string;
   disableTeleport?: boolean;
 }>();
@@ -45,7 +44,7 @@ const emit = defineEmits<{
 }>();
 
 const modalContainer = ref<HTMLDivElement | null>(null);
-const { trapRef, clearFocusTrap, initFocusTrap } = useFocusTrap();
+const { trapRef, clearFocusTrap } = useFocusTrap();
 
 function closeModal() {
   clearFocusTrap();
@@ -54,7 +53,9 @@ function closeModal() {
 
 onMounted(() => {
   // would be good to be dynamic
-  modalContainer.value?.querySelector<HTMLElement>('#modal input')?.focus();
+  modalContainer.value
+    ?.querySelector<HTMLElement>(`#modal ${focusOnElement}`)
+    ?.focus();
 });
 </script>
 

--- a/src/components/templates/GlobalModalTemplate/index.ts
+++ b/src/components/templates/GlobalModalTemplate/index.ts
@@ -1,0 +1,2 @@
+import GlobalModalTemplate from './GlobalModalTemplate.vue';
+export default GlobalModalTemplate;

--- a/src/components/templates/ModalTemplate/index.ts
+++ b/src/components/templates/ModalTemplate/index.ts
@@ -1,2 +1,0 @@
-import ModalTemplate from './ModalTemplate.vue';
-export default ModalTemplate;

--- a/src/components/templates/PositionedModalTemplate/PositionedModalTemplate.vue
+++ b/src/components/templates/PositionedModalTemplate/PositionedModalTemplate.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class=".positioned-modal" ref="trapRef" @keydown.esc.exact="closeModal">
+    <slot name="header">
+      <header class="relative h-10 w-full rounded-t-xl bg-[#f5e178]" />
+    </slot>
+
+    <main class="flex flex-col gap-6 p-4">
+      <slot />
+      <hr v-if="slots.action" />
+      <div v-if="slots.action" class="flex justify-end gap-8 align-bottom">
+        <slot name="action" />
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, useSlots } from 'vue';
+import useFocusTrap from '@/composables/useFocusTrap';
+
+const { focusOnElement } = defineProps<{
+  focusOnElement: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close', show: boolean): void;
+}>();
+
+const slots = useSlots();
+const { trapRef, clearFocusTrap } = useFocusTrap();
+
+function closeModal() {
+  clearFocusTrap();
+  emit('close', true);
+}
+
+onMounted(() => {
+  (trapRef.value as HTMLDivElement)
+    ?.querySelector<HTMLElement>(`.positioned-modal ${focusOnElement}`)
+    ?.focus();
+});
+
+onUnmounted(() => {
+  clearFocusTrap();
+});
+</script>

--- a/src/components/templates/PositionedModalTemplate/index.ts
+++ b/src/components/templates/PositionedModalTemplate/index.ts
@@ -1,0 +1,2 @@
+import PositionedModalTemplate from './PositionedModalTemplate.vue';
+export default PositionedModalTemplate;

--- a/src/views/pages/DefaultLayout/DefaultLayout.vue
+++ b/src/views/pages/DefaultLayout/DefaultLayout.vue
@@ -53,7 +53,7 @@ function handleHeaderPreview(value: boolean) {
 }
 
 //////////////////////
-// Create a Composable
+// TODO: Create a Composable
 
 function sidebarToggleListener(event: KeyboardEvent) {
   if (event.key === 'z' && event.ctrlKey && event.altKey) {


### PR DESCRIPTION
# Description
[comment]: # (Please include a summary of the change and which issue is fixed, if such. Please also include relevant motivation and context. List any dependencies that are required for this change)
[comment]: # (If the PR closes any opened issue, please use 'Fixes #issueID')

Created two `modal` templates, one for static and the other for dynamically positioned `modals`, in order to avoid code repetition and have a base handling of `focusTrap` and basic `emits`.

## Type of change
[comment]: # (They can be: ⭐ Feature | 🐞 Bug | 📙 Documentation | 🧶 Chore | 🧬 Refactor | ⚡ Test | 🌈 Styling | 🔥 Enhancement | 💣 Breaking Change | 📦 Package)

- [x] 🧬 Refactor

## Changes:
[comment]: # (Place here the more granular changes you've made)

- Refactored the `ModalTemplate` making the following changes:
	- Removed `errorMessage` prop from it (unnecessary)
	- Changed the `trapRef` target to the inner `div` element
	- Made the focus partially dynamic using a `prop` for the effect
- Renamed the `ModalTemplate` to `GlobalModalTemplate`
- Updated the `EventModal` with the element to focus on
- Created a `PositionedModalTemplate` template for modals which are dynamically positioned
- Updated the `EventDisplay` to use the `PositionedModalTemplate` template